### PR TITLE
Redesign PDF template, add batch letter generator, extend tests and seed data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,9 @@ create_db:
 seed_db:
 	docker compose exec api python seed/seed_data.py
 
+generate_letters:
+	docker compose exec api python scripts/generate_letters.py
+
 alembic_generate_migration:
 	@read -p "Enter migration message: " keyword; docker compose exec api alembic revision --autogenerate -m "$$keyword"
 
@@ -333,8 +336,9 @@ help:
 	@echo "  pytest_local    Run pytest on the local machine (requires local PostgreSQL service)"
 	@echo ""
 	@echo "Tools and utilities:"
-	@echo "  create_db      runs the create_tables.py script to create the database tables"
-	@echo "  seed_db        Seed the database with sample data"
+	@echo "  create_db      				 runs the create_tables.py script to create the database tables"
+	@echo "  seed_db        				 Seed the database with sample data"
+	@echo "  generate_letters 				 Generate letters for members"
 	@echo "  alembic_generate_migration      Generate a new migration with alembic"
 	@echo "  alembic_upgrade_head            Upgrade to the latest migration"
 	@echo "  alembic_history                 Show the migration history"

--- a/app/pdf/templates/welcome_letter.html.jinja2
+++ b/app/pdf/templates/welcome_letter.html.jinja2
@@ -1,118 +1,168 @@
 <!DOCTYPE html>
 <html lang="fi">
-<head>
-  <meta charset="UTF-8">
-  <style>
-    /* ─── Page Setup ───────────────────────────────── */
-    @page {
-      size: A4;
-      margin: 2cm;
-    }
-    body {
-      margin: 0; /* we’ll handle all spacing ourselves */
-      font-family: "Helvetica", sans-serif;
-      font-size: 9pt;
-      line-height: 1.4;
-    }
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      /* ─── Page Setup ───────────────────────────────── */
+      @page {
+        size: A4;
+        margin: 1.5cm;
+      }
+      body {
+        margin: 0;
+        font-family: "Helvetica", sans-serif;
+        font-size: 10pt;
+        line-height: 1.4;
+      }
 
-    /* ─── Addresses (absolute) ─────────────────────── */
-    .org-address {
-      position: absolute;
-      top: 25mm;   /* adjust to your window */
-      left: 15mm;
-      line-height: 1.2;
-      font-weight: bold;
-    }
-    .member-address-block {
-      position: absolute;
-      top: 40mm;   /* below the org-address */
-      left: 15mm;
-      line-height: 1.2;
-    }
+      /* ─── Addresses (absolute) ─────────────────────── */
+      .org-address {
+        position: absolute;
+        top: 0mm;
+        left: 0mm;
+        line-height: 1.2;
+        font-weight: bold;
+      }
 
-    /* ─── Flow Wrapper ─────────────────────────────── */
-    .content {
-      margin-top: 60mm; /* clear the member-address-block */
-      /* optional: padding: 0 2cm; */
-    }
+      .member-address-block {
+        position: absolute;
+        top: 20mm;
+        left: 0mm;
+        line-height: 1.2;
+      }
 
-    /* ─── Separator ───────────────────────────────── */
-    .section-separator {
-      border: none;
-      border-top: 1px solid black;
-      margin: 2em 0;
-    }
+      /* ─── Flow Wrapper ─────────────────────────────── */
+      .content {
+        margin-top: 40mm;
+      }
 
-    /* ─── Title ───────────────────────────────────── */
-    .title-block h2 {
-      font-size: 11pt;
-      margin: 0;
-    }
+      /* ─── Separator ───────────────────────────────── */
+      .section-separator {
+        border: none;
+        border-top: 1px solid black;
+        margin: 0;
+      }
 
-    /* ─── Body Text ───────────────────────────────── */
-    .body-block {
-      margin-top: 1em;
-      text-align: justify;
-    }
+      /* ─── Title ───────────────────────────────────── */
+      .title-block h2 {
+        font-size: 11pt;
+        margin: 0;
+      }
 
-    /* ─── Payment Info ───────────────────────────── */
-    .payment-block {
-      margin-top: 3em;
-      padding-top: 1em;
-      border-top: 1px solid black;
-      line-height: 1.2;
-    }
+      /* ─── Body Text ───────────────────────────────── */
+      .body-block {
+        margin-top: 1em;
+        text-align: justify;
+      }
 
-    a {
-      color: black;
-      text-decoration: none;
-    }
-  </style>
-</head>
-<body>
+      /* ─── Payment Info ───────────────────────────── */
+      .payment-block {
+        /* margin-top: 3em; */
+        position: absolute;
+        top: 22cm;
+        left: 0mm;
+        padding-top: 1em;
+        border-top: 1px solid black;
+        line-height: 1.2;
+      }
 
-  <!-- 1) Sender’s address (absolute) -->
-  <div class="org-address">
-    ToTac ry<br>
-    Hämeentie 42<br>
-    00100 Helsinki<br>
-    <a href="http://www.organisation.com">www.organisation.com</a>
-  </div>
-
-  <!-- 2) Recipient’s address (absolute) -->
-  <div class="member-address-block">
-    {{ member.first_name }} {{ member.last_name }}<br>
-    {% if member.street_address %}
-      {{ member.street_address }}<br>
-    {% endif %}
-    {{ member.postal_code }} {{ member.city }}
-  </div>
-
-  <!-- 3) Everything below as a “flow” -->
-  <div class="content">
-    <hr class="section-separator">
-
-    <div class="title-block">
-      <h2>Tervetuloa ToTaCin jäseneksi ja mukaan järjestön toimintaan!</h2>
+      a {
+        color: black;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- 1) Sender’s address (absolute) -->
+    <div class="org-address">
+      ToTac ry<br />
+      Hämeentie 42<br />
+      00100 Helsinki<br />
+      <a href="http://www.organisation.com">www.organisation.com</a>
     </div>
 
-    <div class="body-block">
-      <p>Lorem ipsum dolor sit amet…</p>
-      <p>Second paragraph…</p>
+    <!-- 2) Recipient’s address (absolute) -->
+    <div class="member-address-block">
+      {{ member.first_name }} {{ member.last_name }}<br />
+      {% if member.street_address %}
+        {{ member.street_address }}<br />
+      {% endif %}
+      {{ member.postal_code }}
+      {{ member.city }}
     </div>
 
-    <hr class="section-separator">
+    <!-- 3) Everything below as a “flow” -->
+    <div class="content">
+      <hr class="section-separator" />
 
-    <div class="payment-block">
-      <strong>ToTaC RY:N JÄSENMAKSU VUODELLE {{ membership.year }}</strong><br><br>
-      VAIHTOEHTO 1: 30 € / VUOSI<br>
-      VAIHTOEHTO 2: 10 € / VUOSI (opiskelijat, työttömät, eläkeläiset)<br><br>
-      Maksetaan tilille <strong>FI36 4730 0010 123450 / ToTac ry</strong><br>
-      Muista merkitä viitenumero: <strong>{{ member.reference_number }}</strong><br><br>
-      <a href="http://www.organisation.com">http://www.organisation.com</a>
+      <div class="title-block">
+        <h2>Tervetuloa ToTaCin jäseneksi ja mukaan järjestön toimintaan!</h2>
+      </div>
+
+      <div class="body-block">
+        ToTacin kamppailu oikeudenmukaisemman maailmantalouden ja
+        tasapuolisemmin vaurautta jakavan globalisaation puolesta on jatkunut jo
+        seitsemäntoista vuotta. Vaikka moni ToTacin keskeisistä tavoitteista –
+        rahoitusmarkkinoiden verotus, veroparatiisien lakkauttaminen,
+        kansainvälinen velkasovittelumekanismi – odottaa yhä toteutumistaan, on
+        pitkäjänteinen työ tuottanut myös tulosta: vielä vuosituhannen
+        vaihteessa utopistisena pidetty ehdotus rahoitusmarkkinaverosta etenee
+        Euroopassa, ja veroparatiisien vahingollisuus valtioiden taloudelle
+        alkaa olla yleisesti tunnustettu tosiseikka. Kasvava eriarvoisuus ja
+        hallituksen jatkuva leikkauspolitiikka kertoo ToTacin vaatimusten
+        ajankohtaisuudesta. Nyt jos koskaan tarvitaan väsymätöntä työtä
+        sosiaalisesti, taloudellisesti ja ekologisesti kestävämpien ja
+        oikeudenmukaisempien vaihtoehtojen esille tuomiseksi! Maailmamme on
+        perustavanlaatuisen muutoksen kynnyksellä, ja meistä riippuu, mihin tuo
+        muutos johtaa. ToTacia tarvitaan enemmän kuin koskaan! Jotta työtä
+        oikeudenmukaisemman maailman puolesta voidaan jatkaa, tarvitaan sekä
+        innokkaasti toimivia ihmisiä että toiminnan mahdollistavia taloudellisia
+        resursseja. Ilman niitä ToTacia ei olisi olemassa, sillä järjestön
+        toiminta perustuu lähes yksinomaan vapaaehtoistyöhön sekä jäsenmaksuista
+        ja lahjoituksista saataviin tuloihin. Kiitos siis myös Sinulle, että
+        olet päättänyt liittyä ToTacin mukana kamppailuun toisenlaisen, paremman
+        maailman puolesta! ToTacin jäsenenä saat paitsi väylän osallistua
+        konkreettiseen toimintaan maailman muuttamiseksi, myös tilaisuuden
+        tutustua mahtaviin ja aktiivisiin ihmisiin ja viisastua yhdessä yhteistä
+        tietämystä jakamalla. Älä siis epäröi ottaa yhteyttä lähipaikkakuntasi
+        paikallisyhteyshenkilöön päästäksesi heti mukaan toimintaan!
+        Paikallisyhteyshenkilöiden yhteystiedot löydät ToTacin verkkosivuilta
+        osoitteesta www.ToTac.fi. Samoilta verkkosivuilta löydät myös lisää
+        tietoa ToTacin historiasta, ajankohtaiset tiedotteet sekä
+        tapahtumakalenterin. Paras keino pysyä tiedotettuna on liittyä ToTacin
+        sähköpostilistoille. Ellet vielä tiedä kuuluvasi ToTacin yleiseen
+        tiedotukseen käytettävälle sähköpostilistalle,
+        ToTac-lista@cool.kaapeli.fi, lähetä sähköpostia osoitteeseen:
+        ToTac@ToTac.fi . Tiedotuslistaa käytetään vain harvoin lähetettävien,
+        kaikkia jäseniä koskevien tiedotusten lähettämiseen. Jos haluat pysyä
+        paremmin kärryillä toiminnasta ja osallistua aktiivisemmin
+        ajankohtaisista aiheista käytäviin keskusteluihin, pyydä päästä myös
+        ToTacin keskustelulistalle, ToTac-keskustelu@cool.kaapeli.fi.
+        Jäsenasioissa tai osoitteesi muuttuessa voit ottaa yhteyttä
+        jäsenrekisteriin lähettämällä sähköpostia osoitteeseen:
+        jasenet@ToTac.fi. Seuraa meitä myös sosiaalisessa mediassa Facebookissa
+        ja Twitterissä.
+
+        <p>
+          ToTacin hallituksen puolesta, <br />
+          <br />
+          John Doe, puheenjohtaja, <br />
+          Tata Tutikainen, puheenjohtaja,<br />
+          Toto Niikanen, puheenjohtaja,
+        </p>
+      </div>
+
+      <div class="payment-block">
+        <strong>ToTaC RY:N JÄSENMAKSU VUODELLE {{ membership.year }}</strong
+        ><br /><br />
+        VAIHTOEHTO 1: 30 € / VUOSI<br />
+        VAIHTOEHTO 2: 10 € / VUOSI (opiskelijat, työttömät, eläkeläiset)<br /><br />
+        Maksetaan tilille <strong>FI36 4730 0010 123450 / ToTac ry</strong
+        ><br />
+        Muista merkitä viitenumero:
+        <strong>{{ member.reference_number }}</strong><br /><br />
+        <a href="http://www.organisation.com">http://www.organisation.com</a>
+      </div>
     </div>
-  </div>
-
-</body>
+  </body>
 </html>
-

--- a/app/pdf/templates/welcome_letter.html.jinja2
+++ b/app/pdf/templates/welcome_letter.html.jinja2
@@ -1,32 +1,118 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fi">
 <head>
-    <meta charset="UTF-8">
-    <title>Welcome Letter</title>
-    <style>
-        body {
-            font-family: sans-serif;
-            margin: 2em;
-            line-height: 1.6;
-        }
-    </style>
+  <meta charset="UTF-8">
+  <style>
+    /* ─── Page Setup ───────────────────────────────── */
+    @page {
+      size: A4;
+      margin: 2cm;
+    }
+    body {
+      margin: 0; /* we’ll handle all spacing ourselves */
+      font-family: "Helvetica", sans-serif;
+      font-size: 9pt;
+      line-height: 1.4;
+    }
+
+    /* ─── Addresses (absolute) ─────────────────────── */
+    .org-address {
+      position: absolute;
+      top: 25mm;   /* adjust to your window */
+      left: 15mm;
+      line-height: 1.2;
+      font-weight: bold;
+    }
+    .member-address-block {
+      position: absolute;
+      top: 40mm;   /* below the org-address */
+      left: 15mm;
+      line-height: 1.2;
+    }
+
+    /* ─── Flow Wrapper ─────────────────────────────── */
+    .content {
+      margin-top: 60mm; /* clear the member-address-block */
+      /* optional: padding: 0 2cm; */
+    }
+
+    /* ─── Separator ───────────────────────────────── */
+    .section-separator {
+      border: none;
+      border-top: 1px solid black;
+      margin: 2em 0;
+    }
+
+    /* ─── Title ───────────────────────────────────── */
+    .title-block h2 {
+      font-size: 11pt;
+      margin: 0;
+    }
+
+    /* ─── Body Text ───────────────────────────────── */
+    .body-block {
+      margin-top: 1em;
+      text-align: justify;
+    }
+
+    /* ─── Payment Info ───────────────────────────── */
+    .payment-block {
+      margin-top: 3em;
+      padding-top: 1em;
+      border-top: 1px solid black;
+      line-height: 1.2;
+    }
+
+    a {
+      color: black;
+      text-decoration: none;
+    }
+  </style>
 </head>
 <body>
-    <p>Dear {{ member.first_name }} {{ member.last_name }},</p>
 
-    <p>Welcome to our association! We're glad to have you as a member for the year {{ membership.year }}.</p>
+  <!-- 1) Sender’s address (absolute) -->
+  <div class="org-address">
+    ToTac ry<br>
+    Hämeentie 42<br>
+    00100 Helsinki<br>
+    <a href="http://www.organisation.com">www.organisation.com</a>
+  </div>
 
-    <p>Your reference number is: <strong>{{ member.reference_number }}</strong></p>
+  <!-- 2) Recipient’s address (absolute) -->
+  <div class="member-address-block">
+    {{ member.first_name }} {{ member.last_name }}<br>
+    {% if member.street_address %}
+      {{ member.street_address }}<br>
+    {% endif %}
+    {{ member.postal_code }} {{ member.city }}
+  </div>
 
-    <p>
-        The membership fee is €25.
-        If you haven't paid yet, please use your reference number when making the payment.
-    </p>
+  <!-- 3) Everything below as a “flow” -->
+  <div class="content">
+    <hr class="section-separator">
 
-    <p>Thank you for your support!</p>
+    <div class="title-block">
+      <h2>Tervetuloa ToTaCin jäseneksi ja mukaan järjestön toimintaan!</h2>
+    </div>
 
-    <p>Kind regards,<br>
-    The Membership Team</p>
+    <div class="body-block">
+      <p>Lorem ipsum dolor sit amet…</p>
+      <p>Second paragraph…</p>
+    </div>
+
+    <hr class="section-separator">
+
+    <div class="payment-block">
+      <strong>ToTaC RY:N JÄSENMAKSU VUODELLE {{ membership.year }}</strong><br><br>
+      VAIHTOEHTO 1: 30 € / VUOSI<br>
+      VAIHTOEHTO 2: 10 € / VUOSI (opiskelijat, työttömät, eläkeläiset)<br><br>
+      Maksetaan tilille <strong>FI36 4730 0010 123450 / ToTac ry</strong><br>
+      Muista merkitä viitenumero: <strong>{{ member.reference_number }}</strong><br><br>
+      <a href="http://www.organisation.com">http://www.organisation.com</a>
+    </div>
+  </div>
+
 </body>
 </html>
 

--- a/app/pdf/templates/welcome_letter.html.jinja2
+++ b/app/pdf/templates/welcome_letter.html.jinja2
@@ -3,166 +3,223 @@
   <head>
     <meta charset="UTF-8" />
     <style>
+      /* ─── Define your spacing scale & typography ───────────────── */
+      :root {
+        /* Page dimensions & margins */
+        --page-size: A4;
+        --page-margin: 1.5cm;
+
+        /* Horizontal & vertical offsets */
+        --horizontal-offset: 0mm; /* left: 0 */
+        --org-address-top: 0mm; /* sender’s address */
+        --member-address-top: 20mm; /* recipient’s block */
+        --content-margin-top: 40mm; /* flow wrapper */
+        --footer-offset: 0mm; /* footer from bottom */
+        --spacing-reset: 0mm;
+
+        /* Typography */
+        --base-font: Helvetica, sans-serif;
+        --body-font-size: 10pt;
+        --font-weight-bold: bold;
+        --title-font-size: 11pt;
+        --line-height: 1.4;
+        --address-line-height: 1.2;
+        --link-accent-color: #003366;
+        --link-decoration: none;
+        --link-hover-decoration: none;
+        --link-underline-offset: 0.1em; /* move underline down by 0.1em */
+
+        /* Separators */
+        --separator-margin: 0mm;
+        --separator-border: 1px solid black;
+
+        /* Padding & section spacing */
+        --title-padding-top: 1em;
+        --body-section-margin-top: 1em;
+        --footer-padding-top: 1em;
+      }
+
       /* ─── Page Setup ───────────────────────────────── */
       @page {
-        size: A4;
-        margin: 1.5cm;
-      }
-      body {
-        margin: 0;
-        font-family: "Helvetica", sans-serif;
-        font-size: 10pt;
-        line-height: 1.4;
-      }
-
-      /* ─── Addresses (absolute) ─────────────────────── */
-      .org-address {
-        position: absolute;
-        top: 0mm;
-        left: 0mm;
-        line-height: 1.2;
-        font-weight: bold;
-      }
-
-      .member-address-block {
-        position: absolute;
-        top: 20mm;
-        left: 0mm;
-        line-height: 1.2;
-      }
-
-      /* ─── Flow Wrapper ─────────────────────────────── */
-      .content {
-        margin-top: 40mm;
-      }
-
-      /* ─── Separator ───────────────────────────────── */
-      .section-separator {
-        border: none;
-        border-top: 1px solid black;
-        margin: 0;
-      }
-
-      /* ─── Title ───────────────────────────────────── */
-      .title-block h2 {
-        font-size: 11pt;
-        margin: 0;
-      }
-
-      /* ─── Body Text ───────────────────────────────── */
-      .body-block {
-        margin-top: 1em;
-        text-align: justify;
-      }
-
-      /* ─── Payment Info ───────────────────────────── */
-      .payment-block {
-        /* margin-top: 3em; */
-        position: absolute;
-        top: 22cm;
-        left: 0mm;
-        padding-top: 1em;
-        border-top: 1px solid black;
-        line-height: 1.2;
+        size: var(--page-size);
+        margin: var(--page-margin);
       }
 
       a {
         color: black;
         text-decoration: none;
       }
+
+      body {
+        margin: var(--spacing-reset);
+        font-family: var(--base-font);
+        font-size: var(--body-font-size);
+        line-height: var(--line-height);
+      }
+
+      /* ─── Links & Emails in body text ────────────────── */
+      .body-block a {
+        color: var(--link-accent-color);
+        text-decoration: var(--link-decoration);
+        text-underline-offset: var(--link-underline-offset);
+      }
+      .body-block a[href^="mailto:"] {
+        text-underline-offset: var(--link-underline-offset);
+      }
+      /* Optional: show underline only on hover in HTML preview */
+      .body-block a:hover {
+        text-decoration: var(--link-hover-decoration);
+      }
+      /* ─── Addresses (absolute) ─────────────────────── */
+      header address {
+        position: absolute;
+        left: var(--horizontal-offset);
+        line-height: var(--address-line-height);
+      }
+      .org-address {
+        top: var(--org-address-top);
+        font-weight: var(--font-weight-bold);
+      }
+      .member-address {
+        top: var(--member-address-top);
+      }
+
+      /* ─── Flow Wrapper ─────────────────────────────── */
+      main.content {
+        margin-top: var(--content-margin-top);
+      }
+
+      /* ─── Separator ───────────────────────────────── */
+      .section-separator {
+        border: none;
+        border-top: var(--separator-border);
+        margin: var(--separator-margin);
+      }
+
+      /* ─── Title & Body ────────────────────────────── */
+      .title-block h2 {
+        padding-top: var(--title-padding-top);
+        font-size: var(--title-font-size);
+        margin: var(--spacing-reset);
+      }
+      .body-block {
+        margin-top: var(--body-section-margin-top);
+        text-align: justify;
+        hyphens: auto;
+      }
+
+      /* ─── Footer / Payment Info ───────────────────── */
+      footer.payment-block {
+        position: absolute;
+        bottom: var(--footer-offset);
+        left: var(--horizontal-offset);
+        padding-top: var(--footer-padding-top);
+        border-top: var(--separator-border);
+        line-height: var(--address-line-height);
+      }
     </style>
   </head>
+
   <body>
-    <!-- 1) Sender’s address (absolute) -->
-    <div class="org-address">
-      ToTac ry<br />
-      Hämeentie 42<br />
-      00100 Helsinki<br />
-      <a href="http://www.organisation.com">www.organisation.com</a>
-    </div>
+    <header>
+      <!-- 1) Sender’s address -->
+      <address class="org-address">
+        ToTac ry<br />
+        Hitchikers' street 42<br />
+        00100 City<br />
+        <a href="http://www.organisation.com">www.organisation.com</a>
+      </address>
 
-    <!-- 2) Recipient’s address (absolute) -->
-    <div class="member-address-block">
-      {{ member.first_name }} {{ member.last_name }}<br />
-      {% if member.street_address %}
-        {{ member.street_address }}<br />
-      {% endif %}
-      {{ member.postal_code }}
-      {{ member.city }}
-    </div>
+      <!-- 2) Recipient’s address -->
+      <address class="member-address">
+        {%- if member.organisation %}
+          {{ member.organisation }}<br />
+        {%- endif %}
+        {{ member.first_name }}
+        {{ member.last_name }}<br />
+        {%- if member.street_address %}
+          {{ member.street_address }}<br />
+        {%- endif %}
+        {{ member.postal_code }}
+        {{ member.city }}
+        {%- if member.country %}
+          {{ member.country }}<br />
+        {%- endif %}
+      </address>
+    </header>
 
-    <!-- 3) Everything below as a “flow” -->
-    <div class="content">
+    <main class="content">
       <hr class="section-separator" />
 
-      <div class="title-block">
-        <h2>Tervetuloa ToTaCin jäseneksi ja mukaan järjestön toimintaan!</h2>
-      </div>
+      <section class="title-block">
+        <h2>Welcome to ToTaC Lorem ipsum dolor sit amet, consectetur!</h2>
+      </section>
 
-      <div class="body-block">
-        ToTacin kamppailu oikeudenmukaisemman maailmantalouden ja
-        tasapuolisemmin vaurautta jakavan globalisaation puolesta on jatkunut jo
-        seitsemäntoista vuotta. Vaikka moni ToTacin keskeisistä tavoitteista –
-        rahoitusmarkkinoiden verotus, veroparatiisien lakkauttaminen,
-        kansainvälinen velkasovittelumekanismi – odottaa yhä toteutumistaan, on
-        pitkäjänteinen työ tuottanut myös tulosta: vielä vuosituhannen
-        vaihteessa utopistisena pidetty ehdotus rahoitusmarkkinaverosta etenee
-        Euroopassa, ja veroparatiisien vahingollisuus valtioiden taloudelle
-        alkaa olla yleisesti tunnustettu tosiseikka. Kasvava eriarvoisuus ja
-        hallituksen jatkuva leikkauspolitiikka kertoo ToTacin vaatimusten
-        ajankohtaisuudesta. Nyt jos koskaan tarvitaan väsymätöntä työtä
-        sosiaalisesti, taloudellisesti ja ekologisesti kestävämpien ja
-        oikeudenmukaisempien vaihtoehtojen esille tuomiseksi! Maailmamme on
-        perustavanlaatuisen muutoksen kynnyksellä, ja meistä riippuu, mihin tuo
-        muutos johtaa. ToTacia tarvitaan enemmän kuin koskaan! Jotta työtä
-        oikeudenmukaisemman maailman puolesta voidaan jatkaa, tarvitaan sekä
-        innokkaasti toimivia ihmisiä että toiminnan mahdollistavia taloudellisia
-        resursseja. Ilman niitä ToTacia ei olisi olemassa, sillä järjestön
-        toiminta perustuu lähes yksinomaan vapaaehtoistyöhön sekä jäsenmaksuista
-        ja lahjoituksista saataviin tuloihin. Kiitos siis myös Sinulle, että
-        olet päättänyt liittyä ToTacin mukana kamppailuun toisenlaisen, paremman
-        maailman puolesta! ToTacin jäsenenä saat paitsi väylän osallistua
-        konkreettiseen toimintaan maailman muuttamiseksi, myös tilaisuuden
-        tutustua mahtaviin ja aktiivisiin ihmisiin ja viisastua yhdessä yhteistä
-        tietämystä jakamalla. Älä siis epäröi ottaa yhteyttä lähipaikkakuntasi
-        paikallisyhteyshenkilöön päästäksesi heti mukaan toimintaan!
-        Paikallisyhteyshenkilöiden yhteystiedot löydät ToTacin verkkosivuilta
-        osoitteesta www.ToTac.fi. Samoilta verkkosivuilta löydät myös lisää
-        tietoa ToTacin historiasta, ajankohtaiset tiedotteet sekä
-        tapahtumakalenterin. Paras keino pysyä tiedotettuna on liittyä ToTacin
-        sähköpostilistoille. Ellet vielä tiedä kuuluvasi ToTacin yleiseen
-        tiedotukseen käytettävälle sähköpostilistalle,
-        ToTac-lista@cool.kaapeli.fi, lähetä sähköpostia osoitteeseen:
-        ToTac@ToTac.fi . Tiedotuslistaa käytetään vain harvoin lähetettävien,
-        kaikkia jäseniä koskevien tiedotusten lähettämiseen. Jos haluat pysyä
-        paremmin kärryillä toiminnasta ja osallistua aktiivisemmin
-        ajankohtaisista aiheista käytäviin keskusteluihin, pyydä päästä myös
-        ToTacin keskustelulistalle, ToTac-keskustelu@cool.kaapeli.fi.
-        Jäsenasioissa tai osoitteesi muuttuessa voit ottaa yhteyttä
-        jäsenrekisteriin lähettämällä sähköpostia osoitteeseen:
-        jasenet@ToTac.fi. Seuraa meitä myös sosiaalisessa mediassa Facebookissa
-        ja Twitterissä.
-
+      <section class="body-block">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a nisl
+        tortor. Etiam bibendum lacinia tincidunt. Etiam pretium nisl non lacinia
+        sagittis. Phasellus sit amet neque blandit, elementum odio in, feugiat
+        neque. Etiam efficitur sem quis est ultrices, sit amet pellentesque
+        magna rhoncus. Nullam id tortor ac nisi dapibus consequat ac non elit.
+        Pellentesque id magna in lacus pulvinar volutpat. Proin in finibus
+        metus. Pellentesque lacus nisl, accumsan quis ornare viverra, ultricies
+        tempor. Curabitur vestibulum, quam at pretium aliquam, sem nulla pretium
+        diam, eu tincidunt ligula arcu interdum neque. Mauris a ultrices nisl.
+        Duis sem dui, rhoncus vitae vehicula nec, molestie ut nisl. Aliquam
+        ultricies et neque quis sollicitudin. Proin rutrum pharetra urna quis
+        feugiat. Sed porta turpis eget blandit vehicula. Cras dolor ex, suscipit
+        id ipsum consequat, eleifend ornare arcu. Aenean dapibus quis dolor vel
+        hendrerit. Duis condimentum euismod dolor vitae tempus. Nulla rutrum
+        arcu sollicitudin nunc sodales, ut pharetra risus dapibus. Donec sed
+        tortor vel ex volutpat suscipit. Class aptent taciti sociosqu ad litora
+        torquent per conubia nostra, per inceptos himenaeos. Praesent eget ante
+        a velit lobortis dictum et aliquam erat. Morbi a feugiat diam, in
+        consequat orci. Etiam vitae interdum odio. Suspendisse suscipit dui ut
+        libero ultrices, eu ornare justo convallis. Curabitur et feugiat quam.
+        Cras fringilla eu sapien quis iaculis. Curabitur in porta velit. In at
+        rhoncus odio. Nullam id purus eu dui posuere lacinia eu vitae dui.
+        Integer non placerat nibh, nec feugiat arcu. Donec ut lacinia ex. Nunc
+        aliquet condimentum accumsan. Vivamus gravida ligula libero, vitae
+        suscipit justo tempor et. Morbi tempor rutrum egestas. Mauris suscipit
+        quam quis varius condimentum. Cras consectetur elementum bibendum. Class
+        aptent taciti sociosqu per inceptos himenaeos. Pellentesque laoreet diam
+        in efficitur iaculis. Nunc sed urna ullamcorper, congue elit vitae,
+        egestas metus. Cras condimentum ipsum a malesuada accumsan. Pellentesque
+        malesuada mauris vitae varius vestibulum. Vivamus pulvinar vehicula
+        quis.
+        <a href="mailto:ToTac-lista@cool.ipsum.fi">ToTac-lista@cool.ipsum.fi</a>
+        Proin rutrum pharetra urna quis feugiat.
+        <a href="mailto:ToTac@ToTac.fi">ToTac@ToTac.fi</a>. aptent taciti
+        sociosqu per inceptos himenaeos. Pellentesque laoreet diam in efficitur
+        iaculis. Nunc sed urna ullamcorper, congue elit vitae, egestas metus.
+        Cras condimentum ipsum a malesuada accumsan. Pellentesque malesuada
+        mauris vitae varius vestibulum. Vivamus pulvinar vehicula
+        <a href="mailto:ToTac-keskustelu@cool.ipsum.fi"
+          >ToTac-keskustelu@cool.ipsum.fi</a
+        >. Class aptent taciti sociosqu ad litora torquent per conubia nostra,
+        per inceptos himenaeos.
+        <a href="mailto:jasenet@ToTac.fi">jasenet@ToTac.fi</a>. Jäsenasioissa .
+        Class aptent taciti sociosqu ad litora torquent per conubia nostra.
+        <a href="https://facebook.com/ToTacRy">Facebookissa</a> ja
+        <a href="https://twitter.com/ToTacRy">Twitterissä</a>.
         <p>
-          ToTacin hallituksen puolesta, <br />
+          ToTac's board greetings, <br />
           <br />
-          John Doe, puheenjohtaja, <br />
-          Tata Tutikainen, puheenjohtaja,<br />
-          Toto Niikanen, puheenjohtaja,
+          John Doe, spokeperson, <br />
+          Tata Tutikainen, spokeperson,<br />
+          Toto Niikanen, spokeperson.
         </p>
-      </div>
+      </section>
+    </main>
 
-      <div class="payment-block">
-        <strong>ToTaC RY:N JÄSENMAKSU VUODELLE {{ membership.year }}</strong
-        ><br /><br />
-        VAIHTOEHTO 1: 30 € / VUOSI<br />
-        VAIHTOEHTO 2: 10 € / VUOSI (opiskelijat, työttömät, eläkeläiset)<br /><br />
-        Maksetaan tilille <strong>FI36 4730 0010 123450 / ToTac ry</strong
-        ><br />
-        Muista merkitä viitenumero:
-        <strong>{{ member.reference_number }}</strong><br /><br />
-        <a href="http://www.organisation.com">http://www.organisation.com</a>
-      </div>
-    </div>
+    <footer class="payment-block">
+      <strong>ToTaC RY'S MEMBERSHIP FOR {{ membership.year }}</strong
+      ><br /><br />
+      ALTERNATIVE 1: 30 € / YEAR<br />
+      ALTERNATIVE 2: 10 € / YEAR (student, unemployed, retired)<br /><br />
+      Pay to account <strong>FI36 4730 0010 123450 / ToTac ry</strong><br />
+      Remember to use your reference number:
+      <strong>{{ member.reference_number }}</strong><br /><br />
+    </footer>
   </body>
 </html>

--- a/app/scripts/generate_letters.py
+++ b/app/scripts/generate_letters.py
@@ -1,7 +1,14 @@
+#!/usr/bin/env python3
+
 # app/scripts/generate_letters.py
 
+import sys
 from pathlib import Path
 
+# Add /app to PYTHONPATH
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+# Now the rest of your script...
 from database import SessionLocal
 from models import Member
 from pdf.generate_welcome_letter import generate_pdf

--- a/app/seed/seed_data.py
+++ b/app/seed/seed_data.py
@@ -59,6 +59,35 @@ seed_data = [
             {"year": 2023, "amount": 25, "discounted": False},
         ],
     },
+    {
+        "first_name": "Diana",
+        "last_name": "Example",
+        "email": "diana@example.com",
+        "phone": "0400000000",
+        "street_address": "Satamakatu 5 A",
+        "city": "Tampere",
+        "postal_code": "33100",
+        "no_postal_mail": False,
+        "notes": "New member with unpaid membership",
+        "memberships": [
+            {"year": 2025, "amount": 0, "discounted": False},  # Unpaid
+        ],
+    },
+    {
+        "first_name": "Erkki",
+        "last_name": "Legacy",
+        "email": "erkki@example.com",
+        "phone": "0401234567",
+        "street_address": "Aurantie 5 A",
+        "city": "Turku",
+        "postal_code": "20100",
+        "no_postal_mail": False,
+        "notes": "Has 2024 membership, 2025 unpaid",
+        "memberships": [
+            {"year": 2024, "amount": 25, "discounted": False},  # Paid
+            {"year": 2025, "amount": 0, "discounted": False},  # Unpaid
+        ],
+    },
 ]
 
 # Insert members with nested memberships
@@ -75,7 +104,7 @@ for entry in seed_data:
                 year=m["year"],
                 amount=m["amount"],
                 discounted=m["discounted"],
-                is_paid=True,
+                is_paid=m["amount"] > 0,  # Paid if amount > 0
             )
         )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,9 @@ services:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
     ports:
       - "${API_PORT}:8000"
-    volumes:
-      - ./app/seed:/app/seed  # Mounting seed data
+    volumes:  # Temporary volumes for development
+      - ./app/seed:/app/seed
+      - ./app/pdf/templates:/app/pdf/templates
       - ./output:/app/output
     depends_on:
       postgres:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ import os
 os.environ["ENV_FILE"] = ".env.test"
 
 import uuid
+
 import pytest
-from config import settings
 from models import Member
 
 import tests.setup_test_db  # noqa: F401

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def make_member(db_session):
         data = {
             "first_name": "Test",
             "last_name": "User",
-            "email": f"test_{uuid.uuid4().hex}@example.test",
+            "email": f"test_{uuid.uuid4().hex}@example.com",
         }
         data.update(overrides)
 

--- a/tests/test_generate_welcome_letter_route.py
+++ b/tests/test_generate_welcome_letter_route.py
@@ -3,12 +3,12 @@
 from pathlib import Path
 
 import pytest
+from database import get_db
 from fastapi.testclient import TestClient
+from models import Member, Membership
 from sqlalchemy.orm import Session
 
 from app.main import app
-from models import Member, Membership
-from database import get_db
 
 client = TestClient(app)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,8 @@
 # tests/test_main.py
 
-from app.main import app  # Import your FastAPI app
 from fastapi.testclient import TestClient
+
+from app.main import app  # Import your FastAPI app
 
 client = TestClient(app)
 

--- a/tests/test_routes_member_search.py
+++ b/tests/test_routes_member_search.py
@@ -1,0 +1,99 @@
+# tests/test_routes_member_search.py
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from database import get_db
+from models import Membership, Member
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _override_db(db_session):
+    # Ensure all route DB calls use the test session
+    app.dependency_overrides[get_db] = lambda: db_session
+
+
+def create_member_with_two(db_session, make_member):
+    """
+    Create one member (with a unique email via make_member)
+    and two memberships (one paid, one unpaid).
+    """
+    m = make_member(first_name="Alice", last_name="Wonder", city="TestCity")
+    db_session.add_all(
+        [
+            Membership(member_id=m.id, year=2023, amount=25),  # paid
+            Membership(member_id=m.id, year=2024, amount=0),  # unpaid
+        ]
+    )
+    db_session.commit()
+    db_session.refresh(m)
+    return m
+
+
+def test_search_by_reference_found(db_session, make_member):
+    m = create_member_with_two(db_session, make_member)
+    resp = client.get(f"/members/search/{m.reference_number}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["member"]["reference_number"] == m.reference_number
+    assert len(data["member"]["memberships"]) == 2
+
+
+def test_search_by_reference_not_found():
+    resp = client.get("/members/search/9999999999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "subpath, query_value, expected_count",
+    [
+        ("full_name", "Alice", 1),
+        ("name", "Wonder", 1),
+        ("city", "TestCity", 1),
+    ],
+)
+def test_search_variants(db_session, make_member, subpath, query_value, expected_count):
+    # clear out all previous data so only our new member exists
+    db_session.query(Membership).delete()
+    db_session.query(Member).delete()
+    db_session.commit()
+
+    m = create_member_with_two(db_session, make_member)
+    resp = client.get(f"/members/search/{subpath}/{query_value}")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["message"].startswith("Found")
+    assert len(payload.get("results", [])) == expected_count
+
+
+def test_exact_reference_endpoint(db_session, make_member):
+    m = create_member_with_two(db_session, make_member)
+    resp = client.get(f"/members/search/reference/{m.reference_number}")
+    assert resp.status_code == 200
+    assert resp.json()["member"]["id"] == m.id
+
+
+def test_exact_reference_not_found():
+    resp = client.get("/members/search/reference/123456789")
+    assert resp.status_code == 404
+
+
+def test_search_by_postal_code(db_session, make_member):
+    # clear out all previous data
+    db_session.query(Membership).delete()
+    db_session.query(Member).delete()
+    db_session.commit()
+
+    # Create two members with postal_code="00100", plus one with a different code
+    m1 = make_member(city="A-City", postal_code="00100")
+    m2 = make_member(city="B-City", postal_code="00100")
+    _ = make_member(city="C-City", postal_code="99999")
+
+    resp = client.get("/members/search/postal/00100")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["message"].startswith("Found")
+    assert len(payload.get("results", [])) == 2

--- a/tests/test_routes_member_search.py
+++ b/tests/test_routes_member_search.py
@@ -1,11 +1,11 @@
 # tests/test_routes_member_search.py
 
 import pytest
+from database import get_db
 from fastapi.testclient import TestClient
+from models import Member, Membership
 
 from app.main import app
-from database import get_db
-from models import Membership, Member
 
 client = TestClient(app)
 

--- a/tests/test_routes_membership.py
+++ b/tests/test_routes_membership.py
@@ -1,9 +1,9 @@
 # tests/test_routes_membership.py
 import pytest
+from database import get_db
 from fastapi.testclient import TestClient
 
 from app.main import app
-from database import get_db
 
 client = TestClient(app)
 

--- a/tests/test_routes_membership.py
+++ b/tests/test_routes_membership.py
@@ -1,0 +1,29 @@
+# tests/test_routes_membership.py
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from database import get_db
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _override_db(db_session):
+    app.dependency_overrides[get_db] = lambda: db_session
+
+
+def test_create_membership_success(make_member):
+    m = make_member()
+    payload = {"year": 2025, "amount": 10}
+    resp = client.post(f"/members/{m.id}/memberships", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["membership"]["year"] == 2025
+    assert data["membership"]["is_paid"] is True
+
+
+def test_create_membership_member_not_found():
+    resp = client.post("/members/999999/memberships", json={"amount": 5})
+    assert resp.status_code == 404
+    assert "Member not found" in resp.json()["detail"]

--- a/tests/test_routes_misc.py
+++ b/tests/test_routes_misc.py
@@ -1,0 +1,35 @@
+# tests/test_routes_misc.py
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/misc/", {"status": "ok", "message": "API is running"}),
+        ("/misc/health", {"status": "ok", "message": "API is healthy"}),
+        ("/misc/version", {"status": "ok", "message": "API version 0.0.1"}),
+        (
+            "/misc/info",
+            {
+                "status": "ok",
+                "message": "This is a simple API for managing memberships and members.",
+            },
+        ),
+        (
+            "/misc/docs",
+            {
+                "status": "ok",
+                "message": "API documentation is available at /docs or /redoc.",
+            },
+        ),
+    ],
+)
+def test_misc_endpoints(path, expected):
+    resp = client.get(path)
+    assert resp.status_code == 200
+    assert resp.json() == expected


### PR DESCRIPTION
## 🧾 Summary

This PR introduces a redesigned welcome letter template with structured typography and layout, and adds tooling to batch-generate PDFs. It also expands seed data, improves test coverage, and mounts new template volumes into Docker for live development.

---

## ✅ What’s Included

### 📄 Letter Template (HTML/CSS)
- Complete rewrite of `welcome_letter.html.jinja2`:
  - Declarative layout using CSS custom properties
  - Absolute-positioned sender/recipient blocks
  - Sectioned title, body, and payment info
  - Link and email styling
- Placeholder content to be localized/updated later

### 🛠 Makefile Utility
- Added `make generate_letters`:
  ```make
  generate_letters:
  	docker compose exec api python scripts/generate_letters.py
  ```
- Can be chained after `make create_db && make seed_db`

### 🧪 Testing
- Added new route test files:
  - `test_routes_member_search.py` — full coverage of all search endpoints
  - `test_routes_membership.py` — tests `/members/{id}/memberships`
  - `test_routes_misc.py` — validates `/misc/*` endpoints
- Patched `conftest.py` to ensure `example.test → example.com` for better email consistency

### 🌱 Seed Data Enhancements
- Added:
  - **Diana** — new unpaid member (2025)
  - **Erkki** — historical + unpaid membership

### 🐳 Docker Development Volumes
- Mounted:
  - `app/pdf/templates/` for live letter previewing
  - Ensures you can tweak layout without rebuilding the image

---

## 🧪 How to Test

```bash
make create_db
make seed_db
make generate_letters
```

- PDFs saved to `output/letters/`
- API check:
  ```bash
  curl -X POST http://localhost:8000/members/1/generate_welcome_letter
  ```

---

## 🧭 Follow-up Ideas

- Generate PDFs at time of `/new_member` creation
- Automatically email PDF to member

